### PR TITLE
Remove links to non existing repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,6 @@ All credit for the original mods goes to their creators.
 
 [Pixel Fuckery](https://discourse.cataclysmdda.org/t/pixels-various-fuckery/16642)
 
-* [Fris0uman](https://github.com/Fris0uman)
-
-[Extended Freeform mod](https://github.com/Fris0uman/Extended_freeform_mod)
-
-[Easy CBM Mods](https://github.com/Fris0uman/Easy-CBM-Mods)
-
-[No Stomach Mod](https://github.com/Fris0uman/No_Stomach_Mod)
-
-[No Health Mod](https://github.com/Fris0uman/No_Health_Mod)
-
-[No Zombie Revivification](https://github.com/Fris0uman/No_Zombie_Revivification)
-
-[**Tileset:** Chesthole32 Backup](https://github.com/Fris0uman/Chesthole_backup)
-
 * [EnviousBlade](https://github.com/EnviousBlade)
 
 [Pneumatic weapons](https://github.com/EnviousBlade/Pneumatic-Weapons)


### PR DESCRIPTION
I've deleted all those repo because I was not maintaining them anyway. This PR removes them from the list since there's nothing at the end of the links.